### PR TITLE
adding expiration for 1 hour

### DIFF
--- a/functions/auth.js
+++ b/functions/auth.js
@@ -7,6 +7,7 @@ const app = express();
 
 const userData = {
   id: uuid(),
+  exp: Math.floor(Date.now() / 1000) + (60 * 60),
   app_metadata: {
     authorization: {
       roles: ['admin'],


### PR DESCRIPTION
JWT's without an expiration aren't valid. This will include a 1 hour expiration to your JWT.